### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned to v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,3 +12,9 @@
 - Build/test: `dotnet build src/MX.CodDemoReader.sln` produces the package; `dotnet test src` currently runs no tests but stays for workflow compatibility.
 - Versioning/release: Nerdbank.GitVersioning via `version.json`; `release-version-and-tag.yml` creates tags, `release-publish-nuget.yml` pushes the package. Other workflows: `build-and-test.yml`, `pr-verify.yml`, `codequality.yml`, `copilot-setup-steps.yml`, `dependabot-automerge.yml`.
 - Guardrails: demo streams must be readable; decoding assumes little-endian ints; `ReadFromStream` throws on short reads. Keep exceptions clear and avoid altering Huffman frequency order to preserve decoding accuracy.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
 
       - name: Setup .NET
@@ -34,3 +35,14 @@ jobs:
           dotnet-version: |
             9.0.x
             10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+This repo wires the `frasermolyneux-copilot` MCP server for AI coding agents (GitHub Copilot CLI, the Copilot coding agent, etc.). The Copilot setup workflow checks out [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot) at tag `v0.1.0`, builds the MCP server (`mcp-server/`), and `.github/copilot/mcp_config.json` registers it for the coding agent. See [`.github-copilot/mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/v0.1.0/mcp-server/README.md) for the full tool surface, content-root resolution, and per-client wire-up snippets.


### PR DESCRIPTION
Wires the org `frasermolyneux-copilot` MCP server into this repo so the GitHub Copilot coding agent (and any other MCP-capable client) can query the shared instruction/prompt/agent catalog directly instead of relying solely on file loads. Mirrors the pattern already merged in `frasermolyneux/portal-core`, pinned to tag `v0.1.0` on `frasermolyneux/.github-copilot`.

## What changed

- `.github/workflows/copilot-setup-steps.yml` — pin the existing `frasermolyneux/.github-copilot` checkout to `refs/tags/v0.1.0`, add `actions/setup-node@v6` (Node 20.x), and build the MCP server with `npm ci && npm run build` in `.github-copilot/mcp-server`. Existing .NET 9/10 setup is untouched.
- `.github/copilot/mcp_config.json` (new) — registers the `frasermolyneux-copilot` stdio server (`node .github-copilot/mcp-server/dist/index.js`) with `GH_COPILOT_CONTENT_ROOT=.github-copilot` and `tools: ["*"]`.
- `.github/copilot-instructions.md` — appends the canonical `## Org conventions via MCP (when available)` bootstrap snippet (byte-identical to the source-of-truth in `metadata.copilot-instructions`; sha256 prefix `DDAC8AA449794730`, length 1094 bytes with CRLF).
- `README.md` — adds a brief `## Local dev: MCP wire-up` section pointing at `.github-copilot/mcp-server/README.md` at tag `v0.1.0` for the full tool surface and per-client wire-up.

## Notes for reviewers

- The snippet is intentionally conditional: it activates only when a client has the MCP server wired in (this PR does that for the coding agent via `mcp_config.json`); otherwise it reads as a no-op, so behaviour for human readers is unchanged.
- `AGENTS.md` is **not** added in this PR. It does not yet exist in this repo, and creating canonical project metadata from scratch is owned by the separate `update-project-metadata` flow. Once `AGENTS.md` lands, the same snippet should be inserted there byte-identically in a follow-up.
- The `.github-copilot` checkout is pinned to `refs/tags/v0.1.0`, so future catalog or MCP-server changes won't drift this repo without an explicit version bump.